### PR TITLE
fix `mdns2` dependency

### DIFF
--- a/idevice.js
+++ b/idevice.js
@@ -1,4 +1,4 @@
-var mdns    = require('mdns2')
+var mdns    = require('mdns')
   , events  = require('events')
   , util    = require('util');
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "url": "https://github.com/olekenneth/node-idevice-browser"
     },
     "dependencies": {
-        "mdns2": "git+https://github.com/agnat/node_mdns.git"
+        "mdns": "git+https://github.com/agnat/node_mdns.git"
     },
     "keywords": [
         "ios",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "url": "https://github.com/olekenneth/node-idevice-browser"
     },
     "dependencies": {
-        "mdns2": "*"
+        "mdns2": "git+https://github.com/agnat/node_mdns.git"
     },
     "keywords": [
         "ios",


### PR DESCRIPTION
The npm `mdns2` package hasn't been updated yet, but the newer version is needed to build for node 0.12.x ...
